### PR TITLE
EXOGTN-1735: [IE8, IE9] Can not rename Dashboard tab if name contains ac...

### DIFF
--- a/platform-ui-web-eXoResources/src/main/webapp/javascript/eXo/webui/UITabbedDashboard.js
+++ b/platform-ui-web-eXoResources/src/main/webapp/javascript/eXo/webui/UITabbedDashboard.js
@@ -53,7 +53,7 @@ function initTabbedDashboardPortlet(id)
         href += "&portal:isSecure=false";
         href += "&uicomponent=UITabPaneDashboard";
         href += "&op=RenameTabLabel";
-        href += "&objectId=" + input.attr("id");
+        href += "&objectId=" + encodeURIComponent(input.attr("id"));
         href += "&newTabLabel=" + encodeURIComponent(newLabel);
         window.location = href;
       }


### PR DESCRIPTION
...cent chars
