### PR TITLE
EXOGTN-1746 [IE8] [Page Creation Wizard] UI glitch in Time box

### DIFF
--- a/platform-ui-web-eXoResources/src/main/webapp/skin/less/CalendarPicker/Style.less
+++ b/platform-ui-web-eXoResources/src/main/webapp/skin/less/CalendarPicker/Style.less
@@ -124,12 +124,16 @@
 			border: none;
 			.box-shadow(0 0 0 transparent);
 			color: @textColor;
-			text-align: center;	
+			padding:0;
+			width: 25px;
+			height: 18px;
+			line-height: 18px;
+			.center();	
 				&:first-child {
-					text-align: right;padding:0;width: 25px;
+					text-align: right;
 				}
 				&:last-child {
-					text-align: left;padding:0;width: 25px;
+					text-align: left;
 				}
 		}
 	}


### PR DESCRIPTION
Problem analysis:
- IE8 browser doesn't support input:last-child. text last isn't aligned correctly.

Fix description:
- Define style for text of last-child and make it center
