### PR TITLE
Get the corresponding form data field for user experiences

### DIFF
--- a/platform-ui-webui-core/src/main/java/org/exoplatform/webui/bean/ReflectionDataMapping.java
+++ b/platform-ui-webui-core/src/main/java/org/exoplatform/webui/bean/ReflectionDataMapping.java
@@ -22,6 +22,7 @@ package org.exoplatform.webui.bean;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.exoplatform.util.ReflectionUtil;
 import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.form.UIForm;
@@ -111,7 +112,7 @@ public class ReflectionDataMapping implements BeanDataMapping {
             return;
         Class[] classes = new Class[] { uiFormInput.getTypeValue() };
         Method method = ReflectionUtil.getSetBindingMethod(bean, bindingField, classes);
-        method.invoke(bean, new Object[] { uiFormInput.getValue() });
+        method.invoke(bean, new Object[] { StringEscapeUtils.escapeHtml((String) uiFormInput.getValue()) });
     }
 
 }


### PR DESCRIPTION
**Fix description:** 
- In case of search by position, Skills of user experience into search fields:
  Add `StringEscapeUtils.escapeHtml` inside the `invokeSetBindingField()` in order to fit with the corresponding field format (as they were modified during their registration into class `UIExperienceSection` through the escapeHtml method  `uiMap.put(Profile.EXPERIENCES_SKILLS, escapeHtml(skills))`) 
