### PR TITLE
CHAT-928 : Make the presence status display at the same level of the user name

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/platformNavigation/UIUserNavigationPortlet/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/platformNavigation/UIUserNavigationPortlet/Style.less
@@ -134,7 +134,8 @@
       }
       > i {
         font-size: 18px;
-        position: static;
+        position: relative;
+        top: 5px;
       }
       .uiIconUserAvailable:before,
       .uiIconUserOnline:before,
@@ -145,6 +146,7 @@
         content: "\e76e";
         font-size: 11px;
         vertical-align: middle;
+        bottom: 1px;
       }
       .uiIconUserAvailable,
       .uiIconUserOnline {


### PR DESCRIPTION
When accessing the My Profile page, we notice that the presence status icon is not aligned with the user's name, while it should be at the same level. I found that the icon position was set to "static" so i changed it to relative and added some position properties, "bottom" and "top", in order to adjust its position.