### PR TITLE
Fix/ECMS-7906: Add css style for folders name

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/ecms/portlets/explorer/UIFileView/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/ecms/portlets/explorer/UIFileView/Style.less
@@ -43,6 +43,10 @@
 		.nodeName {
 			font-weight: bold;
 			color: @baseColorDark;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            display: block;
 		}
 
 		.nodeLabel {

--- a/platform-ui-skin/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
@@ -32,9 +32,6 @@
     .UIDocumentWorkspace .FileContent .Content .FlashViewer {
 		text-align: center;
 	}
-	.uiWorkingArea .rightContainer {
-         z-index: 0;
-    }
 }
 
 .uiActionBar {


### PR DESCRIPTION
When we add a folder with a long name, it will be all shown with an horizontal scrollbar. In order to fix this problem we need to add ellipsis style to the `nodeName` class.

**Tested on :** platform-5.2.x