### PR TITLE
PLF-8525: Make sure that Forum's css file is only imported for the 'a…

### DIFF
--- a/platform-ui-skin/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/platform-ui-skin/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -117,11 +117,13 @@
   </portlet-skin>
 
   <!--- forum portlet -->
-  <portal-skin>
+  <portlet-skin>
+    <application-name>forum</application-name>
+    <portlet-name>ForumPortlet</portlet-name>
     <skin-name>${exo.skin.name}</skin-name>
-    <skin-module>forum</skin-module>
     <css-path>/skin/css/forum/skin/forum-resources.css</css-path>
-  </portal-skin>
+    <css-priority>1</css-priority>
+  </portlet-skin>
 
   <portlet-skin>
     <application-name>poll</application-name>


### PR DESCRIPTION
…ll' profile. (#297)

In "minimal" profile the Forum is not needed so the css's file for forum shouldn't be loaded.
To fix this i changed the declaration of "forum-resources.css" in gatein-resources.xml from portal to portlet to make sure it is not loaded when working under "minimal" profile.