### PR TITLE
MAINT-24190: Fix max width of tooltip of space

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
@@ -60,6 +60,9 @@
 				margin-left: 110px;
 				height: 112px;
 				overflow: hidden;
+				.tooltip-inner {
+					max-width: 300px!important;
+				}
 				.spaceTitle {
 					max-height: 42px;
 					overflow: hidden;


### PR DESCRIPTION
Problem: the tooltip is hidden when showing the description of the last space in the right.
Solution: reduce the size of max-width.